### PR TITLE
Promote aws-ebs-csi-driver v1.22.0 image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
@@ -62,6 +62,7 @@
     "sha256:a4aa163490c3c2bc1c0782598110f489678b3a2471913deb7ca4cf45137ac59d": ["v1.19.0"]
     "sha256:71885dc32a4a1d7c9a1911589f44dcb92a28551fb60da05b6f2b246e59dac90e": ["v1.20.0"]
     "sha256:8b2fc7001ea60cde9e71ca6f4f1cc43304dd54175471d823e5eb9bce70b336fa": ["v1.21.0"]
+    "sha256:3723f77ba11f03795007eb9f4dbeb065da1dc0989d1089f00ecfb95bb4b8c75e": ["v1.22.0"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
/cc @torredil @Connorjc3

https://console.cloud.google.com/gcr/images/k8s-staging-provider-aws/global/aws-ebs-csi-driver@sha256:8b2fc7001ea60cde9e71ca6f4f1cc43304dd54175471d823e5eb9bce70b336fa/details?project=k8s-staging-provider-aws

Version sanity check:

docker run -it --rm gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3175ce5b08563862ac19b0e9f1e454044b57a3818f3f893ba5666441a4325276 --version Unable to find image 'gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3175ce5b08563862ac19b0e9f1e454044b57a3818f3f893ba5666441a4325276' locally gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3175ce5b08563862ac19b0e9f1e454044b57a3818f3f893ba5666441a4325276: Pulling from k8s-staging-provider-aws/aws-ebs-csi-driver a7710b0edfd4: Already exists
2b2bffb67de0: Already exists
908031d1ea58: Already exists
dd30788d3a20: Pull complete
Digest: sha256:3175ce5b08563862ac19b0e9f1e454044b57a3818f3f893ba5666441a4325276 Status: Downloaded newer image for gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3175ce5b08563862ac19b0e9f1e454044b57a3818f3f893ba5666441a4325276 {
  "driverVersion": "v1.22.0",
  "gitCommit": "",
  "buildDate": "2023-08-14T20:50:37+00:00",
  "goVersion": "go1.20.7",
  "compiler": "gc",
  "platform": "linux/amd64"
}

Multi-arch sanity check:

crane manifest gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3175ce5b08563862ac19b0e9f1e454044b57a3818f3f893ba5666441a4325276 {
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:3723f77ba11f03795007eb9f4dbeb065da1dc0989d1089f00ecfb95bb4b8c75e",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:259e60264b9d1034bf3629a28f0a5cae68a7928055ecfe0d8286c91a879cd900",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:a4e58dafefc74f34fdb6527acac2488acdf876a5806cccd311e2f73108c042c2",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.4737"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:45976fed480e0b898483a677d88343974f06624dc4f8fdeca6bcb1a521eae104",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.1906"
         }
      }
   ]
}%