### PR TITLE
chore: Promote aws-ebs-csi-driver v1.24.0 image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
@@ -67,6 +67,7 @@
     "sha256:1669262267c5b89e94c67ab400d5b8fde95faa60066a1c04082e85e3e76710a9": ["v1.23.0"]
     "sha256:fe9d99c75151a656abbc1dd44312e774bea7ec3da5084dfc7ab824e9f72291cf": ["v1.23.1"]
     "sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae": ["v1.24.0"]
+    "sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae": ["v1.24.0"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
\cc @torredil
\cc @ConnorJC3

 ```Sanity checking gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae
Checking that driver version is v1.24.0
  "driverVersion": "v1.24.0",
Success: Driver version is v1.24.0
Check manifest for all supported images:
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:4db105dd58bc8fde6ccf79e628bdea099b181961ac12f957d2713c4cecd3b2b0",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:36ba022032983eb7228327178c4f03e18bdd2644fe39cbe1baced47c81dcd06f",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:ef59b28bb6c5b29ed8958af3b1ffa340d38b19d25d8fe25e1b71e6441f473a6d",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.4974"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:e8c0e16f21f414315a22084818634671d245603d6bebc94f8c156470f14388d1",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.2031"
         }
      }
   ]
}```